### PR TITLE
Add category pattern to header logo

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -6,7 +6,7 @@
 <style lang="scss">
   .logo {
     font-size: 2rem;
-    background-color: var(--color-primary-bg-static);
+    background-color: transparent; //Allow pattern bg in header to show through
     color: var(--color-gray-1-static);
     text-decoration: none;
     font-family: var(--font-heading);

--- a/src/components/SiteNavHeader.astro
+++ b/src/components/SiteNavHeader.astro
@@ -1,13 +1,22 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import trimTrailingSlash from "../utils/trimTrailingSlash";
 import Logo from "./Logo.astro";
+
+export type Props = {
+  category?: CollectionEntry<"categories">;
+};
+
+const { category } = Astro.props;
+
+const patternClass = category ? `u-pattern-${category.id}` : "";
 
 const isCurrent = (path: string) =>
   trimTrailingSlash(Astro.url.pathname) === path;
 ---
 
 <header class="site-nav-container u-guttered">
-  <nav>
+  <nav class:list={['u-pattern', patternClass]}>
     <a class="skip-to-content-link" href="#main">Skip to Content</a>
     <a class="logo-link" aria-label="Home" href="/">
       <Logo />
@@ -39,14 +48,21 @@ const isCurrent = (path: string) =>
     --u-guttered-content-width: 60rem;
     // border-bottom: 1px solid var(--color-gray-8);
     & nav {
+      &.u-pattern {
+        background-position: bottom;
+      }
       display: flex;
       padding: 0;
-      justify-content: space-between;
       align-items: stretch;
       height: 58px;
 
       ul {
+        //Occlude pattern shown on nav element so that it only shows on the logo
+        background-color: var(--color-gray-1);
+        text-shadow: none;
+        flex: 1;
         display: flex;
+        justify-content: flex-end;
         margin: 0;
         padding: 0;
       }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import type { CollectionEntry } from 'astro:content';
 import '@fontsource-variable/figtree';
 import '@fontsource-variable/faustina';
 import "../styles/_style.scss";
@@ -7,15 +8,17 @@ import SiteNavHeader from "../components/SiteNavHeader.astro";
 import metadata from "../content/_metadata";
 import unMarkdown from '../utils/unMarkdown';
 
+
 export type Props = {
     title: string;
     description: string;
     ogImagePath: string;
+    category?: CollectionEntry<'categories'>;
 };
 
 const defaultTitle = metadata.title;
 
-const { title, description: descriptionRaw, ogImagePath: ogImagePathRaw } = Astro.props;
+const { title, description: descriptionRaw, ogImagePath: ogImagePathRaw, category } = Astro.props;
 
 const titleFull = (title && title !== defaultTitle) ? `${title} - ${defaultTitle}` : defaultTitle;
 
@@ -69,7 +72,7 @@ const description = unMarkdown(descriptionRaw);
     <link rel="manifest" href="/site.webmanifest" />
 
     <body>
-        <SiteNavHeader />
+        <SiteNavHeader category={category} />
         <main id="main">
             <slot />
         </main>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -15,7 +15,7 @@ const { title, description, category, ogImagePath } = Astro.props;
 const patternClass = category ? `u-pattern-${category.id}` : '';
 ---
 
-<Layout title={title} description={description} ogImagePath={ogImagePath}>
+<Layout title={title} description={description} ogImagePath={ogImagePath} category={category}>
     <h1 class:list={[ 'u-pattern', patternClass ]}>
         <span class="u-guttered">{ title }</span>
     </h1>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -42,6 +42,7 @@ const ogImagePath = `/posts/${post.slug}`;
   title={post.data.title}
   description={post.data.description}
   ogImagePath={ogImagePath}
+  category={category}
 >
   <h1 class:list={["u-pattern", patternClass]}>
     <span class="u-guttered">{post.data.title}</span>

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -28,7 +28,7 @@ $svg-color-dark: encodeColor($color-primary-fg);
 
 .u-pattern {
     background-color: var(--color-primary-bg-static);
-    background-position: center;
+    background-position: top;
     color: var(--color-gray-1-static);
     text-shadow: 0 0 6px var(--color-primary-bg-static), 0 0 12px var(--color-primary-bg-static), 0 0 18px var(--color-primary-bg-static);
     &-software {


### PR DESCRIPTION
I had to be sneaky to get it to line up with the pattern behind the page title:

1. Change the anchor point of the page title's pattern bg to `top`.
2. Add the same pattern bg to the nav element in the site header.
3. Set the pattern bg in the nav element to have an anchor point of `bottom`, so that it lines up with the top edge of the pattern in the title.
4. Change everything in the header _except_ the logo to have a white bg to cover the pattern.